### PR TITLE
Add comment DTOs and endpoints for CRUD operations

### DIFF
--- a/AnotherGoodAPI/DTOs/CommentCreateDto.cs
+++ b/AnotherGoodAPI/DTOs/CommentCreateDto.cs
@@ -1,0 +1,16 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace AnotherGoodAPI.DTOs
+{
+    public class CommentCreateDto
+    {
+        [Required, MaxLength(1000)]
+        public string Body { get; set; }
+
+        [Required]
+        public int PostId { get; set; }
+
+        [Required]
+        public string AuthorId { get; set; }
+    }
+}

--- a/AnotherGoodAPI/DTOs/CommentDto.cs
+++ b/AnotherGoodAPI/DTOs/CommentDto.cs
@@ -1,0 +1,11 @@
+﻿namespace AnotherGoodAPI.DTOs
+{
+    public class CommentDto
+    {
+        public int Id { get; set; }
+        public string Body { get; set; }
+        public string AuthorName { get; set; }
+        public int PostId { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/AnotherGoodAPI/DTOs/CommentUpdateDto.cs
+++ b/AnotherGoodAPI/DTOs/CommentUpdateDto.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace AnotherGoodAPI.DTOs
+{
+    public class CommentUpdateDto
+    {
+        [Required, MaxLength(1000)]
+        public string Body { get; set; }
+    }
+}

--- a/AnotherGoodAPI/Endpoints/Comments/CreateCommentEndpoint.cs
+++ b/AnotherGoodAPI/Endpoints/Comments/CreateCommentEndpoint.cs
@@ -1,0 +1,42 @@
+﻿using AnotherGoodAPI.Data;
+using AnotherGoodAPI.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace AnotherGoodAPI.Endpoints.Comments;
+
+public class CreateCommentEndpoint : IEndpointMapper
+{
+    public record Request(int PostId, string Body);
+
+    public void MapEndpoint(WebApplication app)
+    {
+        app.MapPost("/comments", HandleAsync)
+           .WithName("CreateComment")
+           .Produces(StatusCodes.Status201Created)
+           .Produces(StatusCodes.Status400BadRequest)
+           .Produces(StatusCodes.Status401Unauthorized);
+    }
+
+    public async Task<IResult> HandleAsync(Request request, ForumDbContext db, HttpContext http)
+    {
+        var userId = http.User.Identity?.Name;
+        if (userId == null) return Results.Unauthorized();
+
+        var postExists = await db.Posts.AnyAsync(p => p.Id == request.PostId);
+        if (!postExists) return Results.BadRequest("Post does not exist.");
+
+        var comment = new Comment
+        {
+            Body = request.Body,
+            PostId = request.PostId,
+            AuthorId = userId
+        };
+
+        db.Comments.Add(comment);
+        await db.SaveChangesAsync();
+
+        return Results.Created($"/comments/{comment.Id}", comment);
+    }
+}

--- a/AnotherGoodAPI/Endpoints/Comments/DeleteCommentEndpoint.cs
+++ b/AnotherGoodAPI/Endpoints/Comments/DeleteCommentEndpoint.cs
@@ -1,0 +1,34 @@
+﻿using AnotherGoodAPI.Data;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace AnotherGoodAPI.Endpoints.Comments;
+
+public class DeleteCommentEndpoint : IEndpointMapper
+{
+    public void MapEndpoint(WebApplication app)
+    {
+        app.MapDelete("/comments/{id:int}", HandleAsync)
+           .WithName("DeleteComment")
+           .Produces(StatusCodes.Status204NoContent)
+           .Produces(StatusCodes.Status401Unauthorized)
+           .Produces(StatusCodes.Status403Forbidden)
+           .Produces(StatusCodes.Status404NotFound);
+    }
+
+    public async Task<IResult> HandleAsync(int id, ForumDbContext db, HttpContext http)
+    {
+        var userId = http.User.Identity?.Name;
+        if (userId == null) return Results.Unauthorized();
+
+        var comment = await db.Comments.FindAsync(id);
+        if (comment == null) return Results.NotFound();
+
+        if (comment.AuthorId != userId) return Results.Forbid();
+
+        db.Comments.Remove(comment);
+        await db.SaveChangesAsync();
+
+        return Results.NoContent();
+    }
+}

--- a/AnotherGoodAPI/Endpoints/Comments/GetCommentsEndpoint.cs
+++ b/AnotherGoodAPI/Endpoints/Comments/GetCommentsEndpoint.cs
@@ -1,0 +1,27 @@
+﻿using AnotherGoodAPI.Data;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace AnotherGoodAPI.Endpoints.Comments;
+
+public class GetCommentsEndpoint : IEndpointMapper
+{
+    public void MapEndpoint(WebApplication app)
+    {
+        app.MapGet("/comments/post/{postId:int}", HandleAsync)
+           .WithName("GetComments")
+           .Produces(StatusCodes.Status200OK);
+    }
+
+    public async Task<IResult> HandleAsync(int postId, ForumDbContext db)
+    {
+        var comments = await db.Comments
+            .Where(c => c.PostId == postId)
+            .Include(c => c.Author)
+            .OrderBy(c => c.CreatedAt)
+            .ToListAsync();
+
+        return Results.Ok(comments);
+    }
+}

--- a/AnotherGoodAPI/Endpoints/Comments/UpdateCommentEndpoint.cs
+++ b/AnotherGoodAPI/Endpoints/Comments/UpdateCommentEndpoint.cs
@@ -1,0 +1,38 @@
+﻿using AnotherGoodAPI.Data;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace AnotherGoodAPI.Endpoints.Comments;
+
+public class UpdateCommentEndpoint : IEndpointMapper
+{
+    public record Request(string Body);
+
+    public void MapEndpoint(WebApplication app)
+    {
+        app.MapPut("/comments/{id:int}", HandleAsync)
+           .WithName("UpdateComment")
+           .Produces(StatusCodes.Status200OK)
+           .Produces(StatusCodes.Status401Unauthorized)
+           .Produces(StatusCodes.Status403Forbidden)
+           .Produces(StatusCodes.Status404NotFound);
+    }
+
+    public async Task<IResult> HandleAsync(int id, Request request, ForumDbContext db, HttpContext http)
+    {
+        var userId = http.User.Identity?.Name;
+        if (userId == null) return Results.Unauthorized();
+
+        var comment = await db.Comments.FindAsync(id);
+        if (comment == null) return Results.NotFound();
+
+        if (comment.AuthorId != userId) return Results.Forbid();
+
+        comment.Body = request.Body;
+        comment.UpdatedAt = DateTime.UtcNow;
+
+        await db.SaveChangesAsync();
+        return Results.Ok(comment);
+    }
+}

--- a/AnotherGoodAPI/Endpoints/EndpointRegistrar.cs
+++ b/AnotherGoodAPI/Endpoints/EndpointRegistrar.cs
@@ -1,6 +1,7 @@
 ﻿using AnotherGoodAPI.Endpoints.Categories;
 ﻿using AnotherGoodAPI.Endpoints.Posts;
 using AnotherGoodAPI.Endpoints.Users;
+using AnotherGoodAPI.Endpoints.Comments;
 using Microsoft.AspNetCore.Builder;
 
 namespace AnotherGoodAPI.Endpoints
@@ -28,6 +29,12 @@ namespace AnotherGoodAPI.Endpoints
             new GetPostsEndpoint().MapEndpoint(app);
             new GetPostEndpoint().MapEndpoint(app);
             new ToggleLikeEndpoint().MapEndpoint(app);
+
+            // Comments
+            new CreateCommentEndpoint().MapEndpoint(app);
+            new UpdateCommentEndpoint().MapEndpoint(app);
+            new DeleteCommentEndpoint().MapEndpoint(app);
+            new GetCommentsEndpoint().MapEndpoint(app);
         }
     }
 }


### PR DESCRIPTION
Introduced `CommentCreateDto`, `CommentDto`, and `CommentUpdateDto` to define data structures for creating, retrieving, and updating comments with validation attributes.

Added endpoints for comment operations:
- `POST /comments` to create a comment.
- `DELETE /comments/{id:int}` to delete a comment.
- `GET /comments/post/{postId:int}` to retrieve comments for a post.
- `PUT /comments/{id:int}` to update a comment.

Updated `EndpointRegistrar.cs` to register the new comment-related endpoints.