### PR TITLE
Add messaging system with CRUD endpoints

### DIFF
--- a/AnotherGoodAPI/DTOs/DirectMessageCreateDto.cs
+++ b/AnotherGoodAPI/DTOs/DirectMessageCreateDto.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace AnotherGoodAPI.DTOs
+{
+    public class DirectMessageCreateDto
+    {
+        [Required]
+        public string Body { get; set; }
+
+        [Required]
+        public string SenderId { get; set; }
+
+        [Required]
+        public string ReceiverId { get; set; }
+
+        public int? ParentMessageId { get; set; }
+    }
+}

--- a/AnotherGoodAPI/DTOs/DirectMessageDto.cs
+++ b/AnotherGoodAPI/DTOs/DirectMessageDto.cs
@@ -1,0 +1,13 @@
+﻿namespace AnotherGoodAPI.DTOs
+{
+    public class DirectMessageDto
+    {
+        public int Id { get; set; }
+        public string Body { get; set; }
+        public string SenderName { get; set; }
+        public string ReceiverName { get; set; }
+        public DateTime SentAt { get; set; }
+        public bool IsRead { get; set; }
+        public int? ParentMessageId { get; set; }
+    }
+}

--- a/AnotherGoodAPI/Endpoints/EndpointRegistrar.cs
+++ b/AnotherGoodAPI/Endpoints/EndpointRegistrar.cs
@@ -1,7 +1,8 @@
 ﻿using AnotherGoodAPI.Endpoints.Categories;
+using AnotherGoodAPI.Endpoints.Comments;
+using AnotherGoodAPI.Endpoints.Messages;
 ﻿using AnotherGoodAPI.Endpoints.Posts;
 using AnotherGoodAPI.Endpoints.Users;
-using AnotherGoodAPI.Endpoints.Comments;
 using Microsoft.AspNetCore.Builder;
 
 namespace AnotherGoodAPI.Endpoints
@@ -35,6 +36,12 @@ namespace AnotherGoodAPI.Endpoints
             new UpdateCommentEndpoint().MapEndpoint(app);
             new DeleteCommentEndpoint().MapEndpoint(app);
             new GetCommentsEndpoint().MapEndpoint(app);
+
+            // Messages
+            new SendMessageEndpoint().MapEndpoint(app);
+            new MarkAsReadEndpoint().MapEndpoint(app);
+            new GetInboxEndpoint().MapEndpoint(app);
+            new DeleteMessageEndpoint().MapEndpoint(app);
         }
     }
 }

--- a/AnotherGoodAPI/Endpoints/Messages/DeleteMessageEndpoint.cs
+++ b/AnotherGoodAPI/Endpoints/Messages/DeleteMessageEndpoint.cs
@@ -1,0 +1,36 @@
+﻿using AnotherGoodAPI.Data;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace AnotherGoodAPI.Endpoints.Messages;
+
+public class DeleteMessageEndpoint : IEndpointMapper
+{
+    public void MapEndpoint(WebApplication app)
+    {
+        app.MapDelete("/messages/{messageId}", HandleAsync)
+           .WithName("DeleteMessage")
+           .Produces(StatusCodes.Status204NoContent)
+           .Produces(StatusCodes.Status401Unauthorized)
+           .Produces(StatusCodes.Status403Forbidden)
+           .Produces(StatusCodes.Status404NotFound);
+    }
+
+    public async Task<IResult> HandleAsync(int messageId, ForumDbContext db, HttpContext http)
+    {
+        var userId = http.User.Identity?.Name;
+        if (userId == null) return Results.Unauthorized();
+
+        var message = await db.DirectMessages.FindAsync(messageId);
+        if (message == null) return Results.NotFound();
+
+        if (message.SenderId != userId && message.ReceiverId != userId)
+            return Results.Forbid();
+
+        db.DirectMessages.Remove(message);
+        await db.SaveChangesAsync();
+
+        return Results.NoContent();
+    }
+}

--- a/AnotherGoodAPI/Endpoints/Messages/GetInboxEndpoint.cs
+++ b/AnotherGoodAPI/Endpoints/Messages/GetInboxEndpoint.cs
@@ -1,0 +1,32 @@
+﻿using AnotherGoodAPI.Data;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace AnotherGoodAPI.Endpoints.Messages;
+
+public class GetInboxEndpoint : IEndpointMapper
+{
+    public void MapEndpoint(WebApplication app)
+    {
+        app.MapGet("/messages/inbox/{userId}", HandleAsync)
+           .WithName("GetInbox")
+           .Produces(StatusCodes.Status200OK)
+           .Produces(StatusCodes.Status403Forbidden);
+    }
+
+    public async Task<IResult> HandleAsync(string userId, ForumDbContext db, HttpContext http)
+    {
+        var currentUserId = http.User.Identity?.Name;
+        if (currentUserId != userId) return Results.Forbid();
+
+        var messages = await db.DirectMessages
+            .Where(m => m.ReceiverId == userId)
+            .Include(m => m.Sender)
+            .Include(m => m.ParentMessage)
+            .OrderByDescending(m => m.SentAt)
+            .ToListAsync();
+
+        return Results.Ok(messages);
+    }
+}

--- a/AnotherGoodAPI/Endpoints/Messages/MarkAsReadEndpoint.cs
+++ b/AnotherGoodAPI/Endpoints/Messages/MarkAsReadEndpoint.cs
@@ -1,0 +1,35 @@
+﻿using AnotherGoodAPI.Data;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace AnotherGoodAPI.Endpoints.Messages;
+
+public class MarkAsReadEndpoint : IEndpointMapper
+{
+    public void MapEndpoint(WebApplication app)
+    {
+        app.MapPut("/messages/{messageId}/read", HandleAsync)
+           .WithName("MarkAsRead")
+           .Produces(StatusCodes.Status200OK)
+           .Produces(StatusCodes.Status401Unauthorized)
+           .Produces(StatusCodes.Status403Forbidden)
+           .Produces(StatusCodes.Status404NotFound);
+    }
+
+    public async Task<IResult> HandleAsync(int messageId, ForumDbContext db, HttpContext http)
+    {
+        var userId = http.User.Identity?.Name;
+        if (userId == null) return Results.Unauthorized();
+
+        var message = await db.DirectMessages.FindAsync(messageId);
+        if (message == null) return Results.NotFound();
+
+        if (message.ReceiverId != userId) return Results.Forbid();
+
+        message.IsRead = true;
+        await db.SaveChangesAsync();
+
+        return Results.Ok(message);
+    }
+}

--- a/AnotherGoodAPI/Endpoints/Messages/SendMessageEndpoint.cs
+++ b/AnotherGoodAPI/Endpoints/Messages/SendMessageEndpoint.cs
@@ -1,0 +1,44 @@
+﻿using AnotherGoodAPI.Data;
+using AnotherGoodAPI.Models;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace AnotherGoodAPI.Endpoints.Messages;
+
+public class SendMessageEndpoint : IEndpointMapper
+{
+    public void MapEndpoint(WebApplication app)
+    {
+        app.MapPost("/messages", HandleAsync)
+           .WithName("SendMessage")
+           .Produces(StatusCodes.Status201Created)
+           .Produces(StatusCodes.Status400BadRequest)
+           .Produces(StatusCodes.Status401Unauthorized);
+    }
+
+    public record Request(string ReceiverId, string Body, int? ParentMessageId = null);
+    public record Response(DirectMessage Message);
+
+    public async Task<IResult> HandleAsync(Request request, ForumDbContext db, HttpContext http)
+    {
+        var senderId = http.User.Identity?.Name;
+        if (senderId == null) return Results.Unauthorized();
+
+        var receiverExists = await db.Users.AnyAsync(u => u.Id == request.ReceiverId);
+        if (!receiverExists) return Results.BadRequest("Receiver does not exist.");
+
+        var message = new DirectMessage
+        {
+            Body = request.Body,
+            SenderId = senderId,
+            ReceiverId = request.ReceiverId,
+            ParentMessageId = request.ParentMessageId
+        };
+
+        db.DirectMessages.Add(message);
+        await db.SaveChangesAsync();
+
+        return Results.Created($"/messages/{message.Id}", new Response(message));
+    }
+}


### PR DESCRIPTION
Introduced a messaging system with DTOs and endpoints for creating, retrieving, updating, and deleting direct messages.

- Added `DirectMessageCreateDto` and `DirectMessageDto` for message creation and representation.
- Implemented `SendMessageEndpoint` for sending messages.
- Implemented `GetInboxEndpoint` for retrieving user inbox messages.
- Implemented `MarkAsReadEndpoint` for marking messages as read.
- Implemented `DeleteMessageEndpoint` for deleting messages.
- Updated `EndpointRegistrar` to register message-related endpoints.
- Added authorization and validation checks for secure operations.